### PR TITLE
Dashboard url cleanup. Image alt text.

### DIFF
--- a/guides/android/authentication.md
+++ b/guides/android/authentication.md
@@ -21,7 +21,7 @@ A `Provider ID` and `Key ID` must be retained by your back end application and u
 
 %%C-KEYID%%
 
-To manage your authentication keys please visit the [dashboard](/dashboard/projects).
+To manage your authentication keys please visit the [dashboard](/projects).
 
 ##Step 2 - Start the Authentication process
 Once connected, the `onConnectionConnected()` method will be called, at which time you should call the 'authenticate()' method on the `layerClient`.
@@ -45,7 +45,7 @@ public void onAuthenticationChallenge(final LayerClient layerClient, final Strin
     String mUserId = "USER_ID_HERE";
 
   /*
-   *  CODE goes here. Post the nonce to your backend, generate and return an Identity Token  
+   *  CODE goes here. Post the nonce to your backend, generate and return an Identity Token
    */
 }
 ```
@@ -102,4 +102,4 @@ Notify the `layerClient` of the new identity token. Add the following code after
   layerClient.answerAuthenticationChallenge("IDENTITY_TOKEN");
 ```
 
-You can validate your identity token by using our tool here - [identity token validation tool](/dashboard/projects).
+You can validate your identity token by using our tool here - [identity token validation tool](/projects).

--- a/guides/android/push-notification.md
+++ b/guides/android/push-notification.md
@@ -7,58 +7,58 @@ If you do not already have an API Key and Project Number from Google for your ap
 ## Setup Google Cloud Messaging on the Web
 Go to the [Google Developer Console](https://console.developers.google.com) and click `Create Project`.
 
-![image alt text](android-push-0.jpg)
+![](android-push-0.jpg)
 
 Name your project and click `Create`
 
-![image alt text](android-push-1.jpg)
+![](android-push-1.jpg)
 
 Select your newly created project from the project menu and note the numeric `Project Number`. You will need to input this number into the Layer Dashboard. It will also be used when initializing the Layer SDK in your application.
 
-![image alt text](android-push-2.jpg)
+![](android-push-2.jpg)
 
 Under your Project Settings
 
 You must first turn on GCM for this project. To do so, on the left menu navigate to APIs & auth -> APIs.  Then find "Google Cloud Messaging for Android" and switch it from OFF to ON.
 
-![image alt text](android-push-gcm.jpg)
+![](android-push-gcm.jpg)
 
 Next, you must create a new Server API key under APIs & auth -> Credentials
 
-![image alt text](android-push-3.jpg)
+![](android-push-3.jpg)
 
 Under "Public API Access", click "Create new Key".
 
-![image alt text](android-push-4.jpg)
+![](android-push-4.jpg)
 
 In the popup, select "Server key"
 
-![image alt text](android-push-5.jpg)
+![](android-push-5.jpg)
 
 Type `0.0.0.0/0` in the "Accept requests from these server IP addresses" field, and click "Create"
 
-![image alt text](android-push-6.jpg)
+![](android-push-6.jpg)
 
 
 Note the alphanumeric `API Key`. You will need to input this key into the Layer Dashboard.
 
-![image alt text](android-push-7.jpg)
+![](android-push-7.jpg)
 ```
 # Setup Google Cloud Messaging in the Layer Dashboard
 
 Navigate to the Layer Developer Portal and login with your credentials. Select the application for which you would like to upload certificates from the Application drop-down menu. Click on the “Push” section of the left hand navigation.
 
-![image alt text](android-push-8.jpg)
+![](android-push-8.jpg)
 
 Click the `Add Credentials` button.
 
-![image alt text](android-push-9.jpg)
+![](android-push-9.jpg)
 
 Enter you GCM credentials.
 
   * Sender ID: the "Project Number" from your Google Developers Console project.
   * API Key: the "API Key" from your Google Developers Console project.
 
-![image alt text](android-push-10.jpg)
+![](android-push-10.jpg)
 
 When your app is in the background, the LayerClient alerts you to pushes via a broadcast Intent with the `com.layer.sdk.PUSH` action.  Your BroadcastReceiver can then create and post the actual [UI notification](http://developer.android.com/guide/topics/ui/notifiers/notifications.html), or take another action.

--- a/guides/ios/authentication.md
+++ b/guides/ios/authentication.md
@@ -21,7 +21,7 @@ A `Provider ID` and `Key ID` must be retained by your backend application and us
 
 %%C-KEYID%%
 
-To manage your authentication keys please visit the [Layer Dashboard](/dashboard/projects).
+To manage your authentication keys please visit the [Layer Dashboard](/projects).
 
 ##Step 2 - Start the Authentication process
 The main logic will reside in the `requestAuthenticationNonceWithCompletion` method.
@@ -31,7 +31,7 @@ The main logic will reside in the `requestAuthenticationNonceWithCompletion` met
    NSLog(@"Authentication nonce %@", nonce);
 
    /*
-    *  CODE goes here. POST the nonce to your backend, generate and return a JWT identity token  
+    *  CODE goes here. POST the nonce to your backend, generate and return a JWT identity token
     */
 }];
 ```
@@ -92,4 +92,4 @@ Once you have received a valid Identity Token call the following code in the `re
   }];
 ```
 
-You can validate your identity token by using our tool here - [identity token validation tool](/dashboard/projects).
+You can validate your identity token by using our tool here - [identity token validation tool](/projects).

--- a/guides/ios/push-integration.md
+++ b/guides/ios/push-integration.md
@@ -95,8 +95,8 @@ Dictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))
 
 Manually keeping track of unread message counts can be a real pain. Layer can automatically set the badge count to the number of unread messages across all conversations.
 
-To enable this feature, go to the Push section of the [Dashboard](http://developer.layer.com/dashboard) and turn on "Show unread in badges".
-![image alt text](badges.png)
+To enable this feature, go to the Push section of the [Dashboard](http://developer.layer.com) and turn on "Show unread in badges".
+![](badges.png)
 Please note that when you flip the switch the change may take a few minutes to propogate.
 
 To retrieve the badge count in your application, use

--- a/guides/ios/push-integration.md
+++ b/guides/ios/push-integration.md
@@ -95,7 +95,7 @@ Dictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))
 
 Manually keeping track of unread message counts can be a real pain. Layer can automatically set the badge count to the number of unread messages across all conversations.
 
-To enable this feature, go to the Push section of the [Dashboard](http://developer.layer.com) and turn on "Show unread in badges".
+To enable this feature, go to the Push section of the [Dashboard](https://developer.layer.com) and turn on "Show unread in badges".
 ![](badges.png)
 Please note that when you flip the switch the change may take a few minutes to propogate.
 

--- a/guides/ios/push-notification.md
+++ b/guides/ios/push-notification.md
@@ -112,7 +112,7 @@ If you have already created a Provisioning Profile in the past you will need to 
 Please note, Layer supports both production and development Apple Push Notifications. Only one certificate can be uploaded to the Layer developer portal at a time however, so please ensure that you have the correct certificate uploaded for your application at all times.
 ```
 
-Navigate to the [Layer Developer Portal](https://developer.layer.com ) and login with your credentials. Select the application for which you would like to upload certificates from the Application drop-down menu. Click on the “Push” section of the left hand navigation.
+Navigate to the [Layer Developer Portal](https://developer.layer.com) and login with your credentials. Select the application for which you would like to upload certificates from the Application drop-down menu. Click on the “Push” section of the left hand navigation.
 
 ![](ios-push-uploadCert3.jpg)
 

--- a/guides/ios/push-notification.md
+++ b/guides/ios/push-notification.md
@@ -6,25 +6,25 @@ If you do not already have a .p12 certificate press the button below to learn ho
 ##Enable Your App for Push notifications
 Navigate to the [Apple Developer Portal](https://developer.apple.com/) and Log In. Select Certificates, Identifiers, & Profiles on the right side of the page.
 
-![image alt text](ios-push-enable2.jpg)
+![](ios-push-enable2.jpg)
 
 Click Identifiers in the iOS Apps section on the left side of the window.
 
-![image alt text](ios-push-enable3.jpg)
+![](ios-push-enable3.jpg)
 
 Select the App ID for your application and you will see a drop-down menu.
 
-![image alt text](ios-push-enable4.jpg)
+![](ios-push-enable4.jpg)
 
 *Note - Wild Card App IDs do not support push notifications. Ensure you Application Identifier is not a Wild Card ID.*
 
 Scroll down to the `Push Notification` line item. If your application is already enabled for push notifications, the dots next to `Enabled` will be green. If they are gray, you must enable your application to support push notification. Select the `Edit` at the bottom of the drop-down menu.
 
-![image alt text](ios-push-enable5.jpg)
+![](ios-push-enable5.jpg)
 
 Scroll down to `Push Notifications` section and click the checkbox to enable.
 
-![image alt text](ios-push-enable6.jpg)
+![](ios-push-enable6.jpg)
 
 Once your application is enabled for push notifications, you will need to generate both a Production SSL Certificate and a Development SSL Certificate and upload them to Apple. To do so, you must first create a `Certificate Signing Request (CSR)` for both.
 
@@ -34,11 +34,11 @@ Once your application is enabled for push notifications, you will need to genera
 
 Open the Keychain Access application on your Mac. This can be found in Applications → Utilities, or by searching via Spotlight.
 
-![image alt text](ios-push-create2.jpg)
+![](ios-push-create2.jpg)
 
 Once in Keychain Access, navigate to Keychain Access → Certificate Assistant → Request a Certificate From a Certificate Authority
 
-![image alt text](ios-push-create3.jpg)
+![](ios-push-create3.jpg)
 
 In the Certificate Information window, enter the following information. The select `Continue`:
 
@@ -47,11 +47,11 @@ In the Certificate Information window, enter the following information. The sele
 	* The `CA Email Address` field should be left empty.
 	* In the "Request is" group, select the `Saved to disk` option.
 
-![image alt text](ios-push-create4.jpg)
+![](ios-push-create4.jpg)
 
 You will be prompted save the certificate. Give you certificate a name and save it to your desktop.
 
-![image alt text](ios-push-create5.jpg)
+![](ios-push-create5.jpg)
 
 **Note that you must create separate `CSRs` for Production and Development certificates. Follow steps 1 - 5 again to create a second certificate.**
 
@@ -59,19 +59,19 @@ You will be prompted save the certificate. Give you certificate a name and save 
 
 Navigate back to the Apple Developer Portal and select `Create Certificate` in the `Development SSL Certificate` section.
 
-![image alt text](ios-push-upload2.jpg)
+![](ios-push-upload2.jpg)
 
 As you have already created a signing request, you can click on the `Continue` button in the following window.
 
-![image alt text](ios-push-upload3.jpg)
+![](ios-push-upload3.jpg)
 
 Click on `Choose File` to select your certificate from your desktop and upload. Once uploaded, click the Generate button to generate your development `SSL Certificate`.
 
-![image alt text](ios-push-upload4.jpg)
+![](ios-push-upload4.jpg)
 
 Click the Download button to download your certificate to your computer, then click Done.
 
-![image alt text](ios-push-upload5.jpg)
+![](ios-push-upload5.jpg)
 
 Once your certificate is downloaded, double click on the certificate to automatically add it to your Keychain.
 
@@ -79,19 +79,19 @@ Once your certificate is downloaded, double click on the certificate to automati
 
 Open up the Keychain Access application and locate your certificate. Right click on the certificate and select “Export “YOUR_CERTIFICATE_NAME”.
 
-![image alt text](ios-push-upload8.jpg)
+![](ios-push-upload8.jpg)
 
 Save the certificate to your desktop as layer-dev-cert.
 
-![image alt text](ios-push-upload9.jpg)
+![](ios-push-upload9.jpg)
 
 You will be prompted to enter a password.  Remember this password as you will need to provide it to Layer when you upload your certificate.
 
-![image alt text](ios-push-upload10.jpg)
+![](ios-push-upload10.jpg)
 
 You will then be asked to enter the admin password for your computer to complete the export process.
 
-![image alt text](ios-push-upload11.jpg)
+![](ios-push-upload11.jpg)
 
 ##Creating/Refreshing a Provisioning Profile
 
@@ -114,15 +114,15 @@ Please note, Layer supports both production and development Apple Push Notificat
 
 Navigate to the [Layer Developer Portal](https://developer.layer.com ) and login with your credentials. Select the application for which you would like to upload certificates from the Application drop-down menu. Click on the “Push” section of the left hand navigation.
 
-![image alt text](ios-push-uploadCert3.jpg)
+![](ios-push-uploadCert3.jpg)
 
 Click on the `Add Certificate` button.
 
-![image alt text](ios-push-uploadCert4.jpg)
+![](ios-push-uploadCert4.jpg)
 
 Click on the `Choose File` button and select the certificate you saved to your desktop.
 
-![image alt text](ios-push-uploadCert5.jpg)
+![](ios-push-uploadCert5.jpg)
 
 You will be prompted by Layer to input your certificate password. This is the same password you chose when you exported your certificate from the KeyChain Access application.
 
@@ -133,4 +133,4 @@ Expand the section titled “Background Modes”.
 
 If the “Background Modes” on/off switch is toggled to “off”, make sure you toggle it to “ON”. Select the radio buttons next to “Background Fetch” and “Remote Notifications”. This will add the necessary background modes to your application’s Info.plist.
 
-![image alt text](ios-push-xcode-background.jpg)
+![](ios-push-xcode-background.jpg)

--- a/integration/android/querying.md
+++ b/integration/android/querying.md
@@ -84,5 +84,5 @@ List<Conversation> results = layerClient.executeQuery(query, Query.ResultType.OB
 ```
 
 ```emphasis
-For many more query examples, please see the [Advanced Querying Guide](https://developer.layer.com/docs/guides#advanced-querying).
+For many more query examples, please see the [Advanced Querying Guide](/docs/guides#advanced-querying).
 ```

--- a/integration/ios/installation-and-setup.md
+++ b/integration/ios/installation-and-setup.md
@@ -39,20 +39,20 @@ If you do not want to use CocoaPods, you can also clone the LayerKit repository 
 If you clone the `LayerKit` repos or download the source, you will need to drag the framework directly into your project.
 
   1. Open up LayerKit and locate LayerKit.embeddedframework
-    ![image alt text](ios-installation-1.jpg)
+    ![](ios-installation-1.jpg)
 
   2. Drag LayerKit.embeddedframework into the Frameworks folder in your XCode project
-    ![image alt text](ios-installation-2.jpg)
+    ![](ios-installation-2.jpg)
 
   3. Make sure "Copy items into destination group's folder" option is checked
-    ![image alt text](ios-installation-3.jpg)
+    ![](ios-installation-3.jpg)
 
 ## Link Dependencies
 
 LayerKit needs a few other frameworks to be included in your project in order to function properly.
 
   1. In XCode, navigate to your Target Settings
-    ![image alt text](ios-installation-4.jpg)
+    ![](ios-installation-4.jpg)
 
   2. Select the "Build Phases" section and expand the "Link Binary With Libraries". Add the following frameworks to your project:
 
@@ -60,10 +60,10 @@ LayerKit needs a few other frameworks to be included in your project in order to
     * `CFNetwork.framework`
     * `MobileCoreServices.framework`
     * `Security.framework`
-    ![image alt text](ios-installation-5.jpg)
+    ![](ios-installation-5.jpg)
 
   3. Navigate to your "Build Settings" tab and add the `-ObjC` and `-lz` flag to the "Other Linker Flags" setting.
-    ![image alt text](ios-installation-6.jpg)
+    ![](ios-installation-6.jpg)
 
 ```
 

--- a/integration/ios/sending.md
+++ b/integration/ios/sending.md
@@ -136,12 +136,12 @@ Additionally, applications can mark a conversation as read which marks all unrea
 
 ```objectivec
 NSError *error = nil;
-BOOL success = [conversation markAllMessagesAsRead:&error];  
+BOOL success = [conversation markAllMessagesAsRead:&error];
 ```
 
 ## Confirming Message Delivery
 
-There a multiple ways in which Layer developers can confirm message delivery. The simplest mechansim is to visit the Layer [Logs Dashboard](https://developer.layer.com/dashboard/projects/layer-sample/logs) in the Layer developer portal. If the message was succesfully sent, you will see a log similar to the following:
+There a multiple ways in which Layer developers can confirm message delivery. The simplest mechansim is to visit the Layer [Logs Dashboard](/projects/layer-sample/logs) in the Layer developer portal. If the message was succesfully sent, you will see a log similar to the following:
 
 ```
 Dec 02 2014 02:34:27pmSync: User <USER_IDENTIFIER> created a message in conversation <CONVERSATION_IDENTIFIER>.
@@ -152,5 +152,5 @@ Additionally, developers can leverage both the [`LYRQueryController`](#query) ob
 ```emphasis
 **Best Practice**
 
-Layer supports both textual and silent push on iOS. However, textual pushes are more expedient, predictable, and reliable. [Click here](https://support.layer.com/hc/en-us/articles/203174610-Can-I-send-regular-push-notifications-) to learn more. 
+Layer supports both textual and silent push on iOS. However, textual pushes are more expedient, predictable, and reliable. [Click here](https://support.layer.com/hc/en-us/articles/203174610-Can-I-send-regular-push-notifications-) to learn more.
 ```

--- a/quick-start/android/authenticate.md
+++ b/quick-start/android/authenticate.md
@@ -58,5 +58,5 @@ public void onAuthenticationChallenge(final LayerClient layerClient, final Strin
 ```
 
 ```emphasis
-Please note, the Layer Identity Service cannot be used in production applications. You will need to implement the backend portion of Layer authentication prior to launching into production. Please see the [Layer Authentication Guide](https://developer.layer.com/docs/guides/android#authentication) for information on doing so.
+Please note, the Layer Identity Service cannot be used in production applications. You will need to implement the backend portion of Layer authentication prior to launching into production. Please see the [Layer Authentication Guide](/docs/guides/android#authentication) for information on doing so.
 ```

--- a/quick-start/android/display-messages.md
+++ b/quick-start/android/display-messages.md
@@ -59,4 +59,4 @@ public String getMessageText(Message msg) {
 }
 ```
 
-To detect changes to conversations or messages, take a look at the [Synchronization](https://developer.layer.com/docs/integration/android#synchronization) guide.
+To detect changes to conversations or messages, take a look at the [Synchronization](/docs/integration/android#synchronization) guide.

--- a/quick-start/android/send-a-message.md
+++ b/quick-start/android/send-a-message.md
@@ -15,6 +15,6 @@ Message message = layerClient.newMessage(Arrays.asList(messagePart));
 conversation.send(message);
 ```
 
-You can verify that your message has been sent by looking at the logs inside [developer dashboard](/dashboard/projects).
+You can verify that your message has been sent by looking at the logs inside [developer dashboard](/projects).
 
 %%C-CHATWIDGET%%

--- a/quick-start/ios/authenticate.md
+++ b/quick-start/ios/authenticate.md
@@ -41,7 +41,7 @@ Layer will cache authentication details so you only need authenticate users if y
 }
 
 - (void)authenticationTokenWithUserId:(NSString *)userID completion:(void (^)(BOOL success, NSError* error))completion{
-    
+
     /*
      * 1. Request an authentication Nonce from Layer
      */
@@ -52,7 +52,7 @@ Layer will cache authentication details so you only need authenticate users if y
             }
             return;
         }
-        
+
         /*
          * 2. Acquire identity Token from Layer Identity Service
          */
@@ -63,7 +63,7 @@ Layer will cache authentication details so you only need authenticate users if y
                 }
                 return;
             }
-            
+
             /*
              * 3. Submit identity token to Layer for validation
              */
@@ -89,17 +89,17 @@ The following code snippet connects to the sample `Layer Identity Service`,  gen
     NSParameterAssert(appID);
     NSParameterAssert(nonce);
     NSParameterAssert(completion);
-    
+
     NSURL *identityTokenURL = [NSURL URLWithString:@"https://layer-identity-provider.herokuapp.com/identity_tokens"];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:identityTokenURL];
     request.HTTPMethod = @"POST";
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    
+
     NSDictionary *parameters = @{ @"app_id": appID, @"user_id": userID, @"nonce": nonce };
     NSData *requestBody = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
     request.HTTPBody = requestBody;
-    
+
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -107,7 +107,7 @@ The following code snippet connects to the sample `Layer Identity Service`,  gen
             completion(nil, error);
             return;
         }
-        
+
         // Deserialize the response
         NSDictionary *responseObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
         if(![responseObject valueForKey:@"error"])
@@ -124,15 +124,15 @@ The following code snippet connects to the sample `Layer Identity Service`,  gen
                NSLocalizedDescriptionKey: @"Layer Identity Provider Returned an Error.",
                NSLocalizedRecoverySuggestionErrorKey: @"There may be a problem with your APPID."
             };
-           
+
             NSError *error = [[NSError alloc] initWithDomain:domain code:code userInfo:userInfo];
             completion(nil, error);
         }
-        
+
     }] resume];
 }
 ```
 
 ```emphasis
-Please note, the Layer Identity Service cannot be used in production applications. You will need to implement the backend portion of Layer authentication prior to launching into production. Please see the [Layer Authentication Guide](https://developer.layer.com/docs/guides/ios#authentication) for information on doing so.
+Please note, the Layer Identity Service cannot be used in production applications. You will need to implement the backend portion of Layer authentication prior to launching into production. Please see the [Layer Authentication Guide](/docs/guides/ios#authentication) for information on doing so.
 ```

--- a/quick-start/ios/connect.md
+++ b/quick-start/ios/connect.md
@@ -21,7 +21,7 @@ self.layerClient = [LYRClient clientWithAppID:appID];
     } else {
     	  // For the purposes of this Quick Start project, let's authenticate as a user named 'Device'.  Alternatively, you can authenticate as a user named 'Simulator' if you're running on a Simulator.
         NSString *userIDString = @"Device";
-        // Once connected, authenticate user.  
+        // Once connected, authenticate user.
         // Check Authenticate step for authenticateLayerWithUserID source
         [self authenticateLayerWithUserID:userIDString completion:^(BOOL success, NSError *error) {
             if (!success) {
@@ -33,5 +33,5 @@ self.layerClient = [LYRClient clientWithAppID:appID];
 ```
 
 ```emphasis
-Please note, `self.layerClient` is a property of the AppDelegate in the above example. The source for `authenticateLayerWithUserID` is included in the next step in [Quick Start](https://developer.layer.com/docs/quick-start/ios#authenticate).
+Please note, `self.layerClient` is a property of the AppDelegate in the above example. The source for `authenticateLayerWithUserID` is included in the next step in [Quick Start](/docs/quick-start/ios#authenticate).
 ```

--- a/quick-start/ios/display-messages.md
+++ b/quick-start/ios/display-messages.md
@@ -1,5 +1,5 @@
 #Display Messages
-The following demonstrates the logic needed to display messages from the last conversation between 2 participants inside a tableview in a View Controller.  The following code heavily relies on the [LYRQueryController](http://developer.layer.com/docs/integration/ios#LYRQueryController).  For a working example, check out the [Quick Start iOS XCode project](https://github.com/layerhq/quick-start-ios).
+The following demonstrates the logic needed to display messages from the last conversation between 2 participants inside a tableview in a View Controller.  The following code heavily relies on the [LYRQueryController](/docs/integration/ios#LYRQueryController).  For a working example, check out the [Quick Start iOS XCode project](https://github.com/layerhq/quick-start-ios).
 
 Initial setup for your View Controller:
 ```objectivec
@@ -20,20 +20,20 @@ Initial setup for your View Controller:
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    // Fetches all conversations between the authenticated user and the supplied participant    
+    // Fetches all conversations between the authenticated user and the supplied participant
     [self fetchLayerConversation];
 }
 ```
 The following methods fetch the last conversation, and populate the query controller with all the messages from that conversations.
 ```objectivec
 - (void)fetchLayerConversation
-{    
+{
      // For the purposes of this Quick Start project, we want fetch any conversations with these 3 users 'Device' (the authenticated user id), 'Simulator', and 'Dashboard'.
     LYRQuery *query = [LYRQuery queryWithClass:[LYRConversation class]];
     query.predicate = [LYRPredicate predicateWithProperty:@"participants" operator:LYRPredicateOperatorIsEqualTo value:@[ @"Device", @"Simulator", @"Dashboard" ]];
 
     query.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"createdAt" ascending:NO] ];
-    
+
     NSError *error;
     NSOrderedSet *conversations = [self.layerClient executeQuery:query error:&error];
     if (!error) {
@@ -41,7 +41,7 @@ The following methods fetch the last conversation, and populate the query contro
     } else {
         NSLog(@"Query failed with error %@", error);
     }
-    
+
     // Retrieve the last conversation
     if (conversations.count) {
         self.conversation = [conversations lastObject];
@@ -52,16 +52,16 @@ The following methods fetch the last conversation, and populate the query contro
 }
 
 -(void)setupQueryController
-{    
+{
     // Query for all the messages in conversation sorted by index
     LYRQuery *query = [LYRQuery queryWithClass:[LYRMessage class]];
     query.predicate = [LYRPredicate predicateWithProperty:@"conversation" operator:LYRPredicateOperatorIsEqualTo value:self.conversation];
     query.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"index" ascending:NO]];
-    
+
     // Set up query controller
     self.queryController = [self.layerClient queryControllerWithQuery:query];
     self.queryController.delegate = self;
-    
+
     NSError *error;
     BOOL success = [self.queryController execute:&error];
     if (success) {
@@ -127,13 +127,13 @@ The following methods are the Table View Data Source Methods.  These methods han
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     static NSString *simpleTableIdentifier = @"SimpleTableCell";
-    
+
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:simpleTableIdentifier];
-    
+
     if (cell == nil) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:simpleTableIdentifier];
     }
-    
+
     return cell;
 }
 
@@ -141,7 +141,7 @@ The following methods are the Table View Data Source Methods.  These methods han
 {
     // Get Message Object from queryController
     LYRMessage *message = [self.queryController objectAtIndexPath:indexPath];
-    
+
     // Set cell text to "<Sender>: <Message Contents>"
     LYRMessagePart *messagePart = message.parts[0];
     cell.textLabel.text = [NSString stringWithFormat:@"%@:%@",[message sentByUserID], [[NSString alloc] initWithData:messagePart.data encoding:NSUTF8StringEncoding]];

--- a/quick-start/ios/install.md
+++ b/quick-start/ios/install.md
@@ -1,6 +1,6 @@
 #Installation
 
-This Quick Start guide will get you up and running with sending messages as quickly as possible. If you are interested in trying out Atlas, Layer's open source user interface components, visit [Experience Atlas](https://developer.layer.com/dashboard/signup/atlas).
+This Quick Start guide will get you up and running with sending messages as quickly as possible. If you are interested in trying out Atlas, Layer's open source user interface components, visit [Experience Atlas](https://developer.layer.com/signup/atlas).
 
 ```emphasis
 Before you get started, we highly recommend that you download the [Quick Start iOS XCode project](https://github.com/layerhq/quick-start-ios). To install the Quick Start iOS XCode project execute this command from your Terminal window:

--- a/quick-start/ios/install.md
+++ b/quick-start/ios/install.md
@@ -1,6 +1,6 @@
 #Installation
 
-This Quick Start guide will get you up and running with sending messages as quickly as possible. If you are interested in trying out Atlas, Layer's open source user interface components, visit [Experience Atlas](https://developer.layer.com/signup/atlas).
+This Quick Start guide will get you up and running with sending messages as quickly as possible. If you are interested in trying out Atlas, Layer's open source user interface components, visit [Experience Atlas](/signup/atlas).
 
 ```emphasis
 Before you get started, we highly recommend that you download the [Quick Start iOS XCode project](https://github.com/layerhq/quick-start-ios). To install the Quick Start iOS XCode project execute this command from your Terminal window:

--- a/quick-start/ios/send-a-message.md
+++ b/quick-start/ios/send-a-message.md
@@ -1,5 +1,5 @@
 #Send a Message
-The following demonstrates the logic needed to create a conversation and send a message between 3 users named "Device", "Simulator", and "Dashboard". 
+The following demonstrates the logic needed to create a conversation and send a message between 3 users named "Device", "Simulator", and "Dashboard".
 
 ```objectivec
 - (void)sendMessage:(NSString *)messageText{
@@ -12,13 +12,13 @@ The following demonstrates the logic needed to create a conversation and send a 
             NSLog(@"New Conversation creation failed: %@", error);
         }
     }
-    
+
     // Creates a message part with text/plain MIME Type
     LYRMessagePart *messagePart = [LYRMessagePart messagePartWithText:messageText];
-    
+
     // Creates and returns a new message object with the given conversation and array of message parts
     LYRMessage *message = [self.layerClient newMessageWithParts:@[messagePart] options:@{LYRMessageOptionsPushNotificationAlertKey: messageText} error:nil];
-    
+
     // Sends the specified message
     NSError *error;
     BOOL success = [self.conversation sendMessage:message error:&error];
@@ -34,5 +34,4 @@ The following demonstrates the logic needed to create a conversation and send a 
 Please note, `self.conversation` is a property of the ViewController in the above example. Check the [Quick Start iOS XCode project](https://github.com/layerhq/quick-start-ios) for more details.
 ```
 
-You can verify that your message has been sent by looking at the logs inside [developer dashboard](/dashboard/projects). Once you've sent a message, learn how to [display messages](http://developer.layer.com/docs/quick-start/ios#display-messages).
- 
+You can verify that your message has been sent by looking at the logs inside [developer dashboard](/projects). Once you've sent a message, learn how to [display messages](/docs/quick-start/ios#display-messages).

--- a/transition/android/transition-guide.md
+++ b/transition/android/transition-guide.md
@@ -11,7 +11,7 @@ LayerClient client = LayerClient.newInstance(Context context, String App_ID, Str
 //MessagePart.newInstance(text) becomes
 MessagePart part = client.newMessagePart(text);
 
-//Message.newInstance(conversation, parts) is created with the client, and does not require 
+//Message.newInstance(conversation, parts) is created with the client, and does not require
 // a conversation object
 Message message = client.newMessage(parts);
 
@@ -62,7 +62,7 @@ public int getUnreadMessageCount(Conversation conversation){
         .build();
 
     List<Message> results = layerClient.executeQuery(query, Query.ResultType.OBJECTS);
-    
+
     if(results == null)
         return 0;
     return results.size();
@@ -70,4 +70,4 @@ public int getUnreadMessageCount(Conversation conversation){
 ```
 
 ##Querying
-One of the biggest changes to SDK version 0.9.+ is Querying. Queries can be executed on a variety of message and conversation properties, and the results can be sorted based on specific fields, allowing for a variety of UI configurations. To learn more about Querying, start with [this guide](https://developer.layer.com/docs/integration/android#querying).
+One of the biggest changes to SDK version 0.9.+ is Querying. Queries can be executed on a variety of message and conversation properties, and the results can be sorted based on specific fields, allowing for a variety of UI configurations. To learn more about Querying, start with [this guide](/docs/integration/android#querying).


### PR DESCRIPTION
Layer developer dashboard url schema changed recently from developer.layer.com/dashboard/ to simply developer.layer.com. We removed the redundant `/dashboard/` prefix.

This pull request follows the new schema.

Also removing `alt image text` from markdown.