### PR TITLE
Fixing all broken headers on iOS

### DIFF
--- a/ios/atlas/core-components.md
+++ b/ios/atlas/core-components.md
@@ -1,10 +1,10 @@
-#Core Components
+# Core Components
 ## Controllers
 To implement Atlas fully, you must at least subclass these view controllers:
 1. [Conversation List View Controller](#clvc) - List of Conversations
 2. [Conversation View Controller](#cvc) - List of Messages and Input
 
-##<a name="clvc"></a> Conversation List View Controller (ATLConversationListViewController)
+## <a name="clvc"></a> Conversation List View Controller (ATLConversationListViewController)
 The Conversation List View Controller is a `UITableViewController` that contains a list of all the conversations that the authenticated user ID belongs to. By default, the cell will contain a title and will show the last message text in conversation.
 
 ### Initializing
@@ -51,7 +51,7 @@ When the user selects a conversation, the `ATLConversationListViewController` no
 - (void)conversationListViewController:(ATLConversationListViewController *)conversationListViewController didSearchForText:(NSString *)searchText completion:(void (^)(NSSet *filteredParticipants))completion;
 ```
 
-##<a name="cvc"></a> Conversation View Controller (ATLConversationViewController)
+## <a name="cvc"></a> Conversation View Controller (ATLConversationViewController)
 The Conversation View Controller is a `UICollectionViewController` that contains all the messages in the conversation. The area at the top where the participants are listed is called the Address Bar. The area at the bottom of the screen where the user can input text, select an image, or send a location is called the Message Input Toolbar. 
 
 ### Initializing

--- a/ios/atlas/plug-in-your-users.md
+++ b/ios/atlas/plug-in-your-users.md
@@ -1,7 +1,7 @@
-#Add Your Users to Atlas
+# Add Your Users to Atlas
 Layer recognizes that you might already have a User Model in your app.  Atlas can work with any User Model as long as it conforms to the `ATLParticipant` protocol.
 
-##<a name="atlp"></a> ATLParticipant Protocol
+## <a name="atlp"></a> ATLParticipant Protocol
 
 ```objective-c
 // The first name of the participant as it should be presented in the user interface.
@@ -28,7 +28,7 @@ When creating a conversation, there are 2 different view controllers that need t
 2. [Participant Table View Controller](#ptvc) - List of total Users 
 Both View Controllers assume the list of participants
 
-##<a name="abvc"></a> Address Bar View Controller (ATLAddressBarViewController)
+## <a name="abvc"></a> Address Bar View Controller (ATLAddressBarViewController)
 The Address Bar View Controller appears at the top of the ATLConversationViewController. When creating a new conversation you can add the participants in the view, or initiate the the Participant Table View Controller. If the conversation exists then the address will contain a read-only list of participants.
 
 ### Initialization
@@ -81,7 +81,7 @@ When the user types in the Address Bar, the `ATLAddressBarViewController` notifi
 - (void)addressBarViewControllerDidSelectWhileDisabled:(ATLAddressBarViewController *)addressBarViewController;
 ```
 
-##<a name="ptvc"></a> Participant Table View Controller  (ATLParticipantTableViewController)
+## <a name="ptvc"></a> Participant Table View Controller  (ATLParticipantTableViewController)
 The Participant Table View Controller is a `UITableViewController` that contains all the participants the authenticated user can message.
 
 ###  Notification when Participant is selected

--- a/ios/guides/authentication.md
+++ b/ios/guides/authentication.md
@@ -6,7 +6,7 @@ Once you are ready for production implementation, you will need to write your ow
 
 To authenticate a user, the SDK requires that your backend server application generate an identity token and return it to your application.
 
-##Step 1 - Backend Setup
+## Step 1 - Backend Setup
 A `Provider ID` and `Key ID` must be retained by your backend application and used in the generation of the token.
 
 ```emphasis
@@ -36,7 +36,7 @@ The main logic will reside in the `requestAuthenticationNonceWithCompletion` met
 }];
 ```
 
-##Step 3 - POST the nonce and generate identity token
+## Step 3 - POST the nonce and generate identity token
 A nonce value will be obtained from Layer and passed into the completion block of the `requestAuthenticationNonceWithCompletion` method. POST this value to your backend and use it to generate a JWT identity token.
 
 A Layer `Identity Token` is a JSON Web Token (JWT) structure that encodes a cryptographically signed set of claims that assert the identity of a particular user within your application. A JWT is transmitted as a compact string value that is formed by concatenating a pair of JSON dictionary structures (the JOSE Header and JWT Claims Set) and a cryptographic signature generated over them. The structure is as follows:
@@ -85,7 +85,7 @@ Third Party Libraries
 
 If you build your own libraries and want to be included, send an email to [support@layer.com](mailto:support@layer.com).
 
-##Step 4 - Notify Layer Client when your backend returns the token
+## Step 4 - Notify Layer Client when your backend returns the token
 Once you have received a valid Identity Token call the following code in the `requestAuthenticationNonceWithCompletion` method
 
 ```objectivec

--- a/ios/guides/policies.md
+++ b/ios/guides/policies.md
@@ -2,7 +2,7 @@
 
 Very often you will want control how your users communicate with each other or how your app communicates with your users. For example, a user may want to block another user or your app may want to blacklist another user. To this end, Layer has introduced the concept of Policy: a set of rules by which different actors and actions in the system are determined and governed. Policies are represented by the `LYRPolicy` class.
 
-##Fetching Policies
+## Fetching Policies
 
 To acquire all the policies, access `policies` property of `LYRClient`. To acquire all polices applied to an individual participant you can filter by using a `NSPredicate`:
 
@@ -16,7 +16,7 @@ for (LYRPolicy *policy in filteredPolicies.array) {
 }
  ```    
 
-##Blocking
+## Blocking
 
 Block is a user policy that defines how two users in your app can communicate. The action of blocking a user results in the Blockee losing certain privileges in relation to the Blocker. For more in-depth information about blocking check out [What happens when I apply a Block policy?](https://support.layer.com/hc/en-us/articles/204050814)
 

--- a/ios/guides/push-integration.md
+++ b/ios/guides/push-integration.md
@@ -1,4 +1,4 @@
-#Register Your App to Receive Remote Notifications
+# Register Your App to Receive Remote Notifications
 
 Your application must register to receive remote notifications. To support device registration for both iOS 7 and iOS 8, your application must implement the following. We recommend you do this in  `application:didFinishLaunchingWithOptions`.
 
@@ -34,7 +34,7 @@ Your AppDelegate will be notified when your application has successfully registe
 To unregister a user from receiving push notifications, you can pass `nil` to the `updateRemoteNotificationDeviceToken` method.
 ```
 
-##Triggering Alerts
+## Triggering Alerts
 
 By default, the Layer Push Notification service will deliver silent push notifications which will not trigger any alerts for your users. However, you can configure your messages to trigger a system alert at the time of message send. To specify the alert text you would like the recipient of a message to receive, you set the `options` dictionary when initializing the [LYRMessage](/docs/ios/api#lyrmessage) object.  In the `options` dictionary you will need to set push text as the value for the `LYRMessageOptionsPushNotificationAlertKey` key. This will tell the Layer Push Notification service to deliver a Text APN and trigger an alert for the user. If you want to send along a sound with the push you can add `LYRMessageOptionsPushNotificationSoundNameKey` to the options.
 
@@ -74,7 +74,7 @@ You can also include user-specific push messages and sounds by using the `LYRMes
 
 If the options parameter is `nil`, the Layer push notification service will deliver your message via a silent push notification (see the [WARNING](#warning) below about silent notifications).
 
-##<a name="warning"></a>
+<a name="warning"></a>
 ```emphasis
 **WARNING about silent and local notifications:**
 
@@ -153,7 +153,7 @@ Dictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))
 }
 ```
 
-##<a name="badges"></a>Showing unread counts as Badges
+## <a name="badges"></a>Showing unread counts as Badges
 
 Manually keeping track of unread message counts can be a real pain. Layer can automatically set the badge count to the number of unread messages across all conversations.
 
@@ -166,7 +166,7 @@ To retrieve the badge count in your application, use
 NSInteger badgeCount = application.applicationIconBadgeNumber;
 ```
 
-##<a name="warning"></a>
+<a name="warning"></a>
 ```emphasis
 **Troubleshooting Push**
 

--- a/ios/guides/push-notification.md
+++ b/ios/guides/push-notification.md
@@ -1,9 +1,9 @@
-#Push Notifications
+# Push Notifications
 The Layer Push Notification Service can be used to keep your application’s data up to date at all times. This guide will walk you through integrating the Layer Push Notification service into your application.
 
-#Generating Apple Push Certificate
+# Generating Apple Push Certificate
 If you do not already have a .p12 certificate press the button below to learn how to generate them from Apple.
-##Enable Your App for Push notifications
+## Enable Your App for Push notifications
 Navigate to the [Apple Developer Portal](https://developer.apple.com/) and Log In. Select Certificates, Identifiers, & Profiles on the right side of the page.
 
 ![image alt text](ios-push-enable2.jpg)
@@ -30,7 +30,7 @@ Once your application is enabled for push notifications, you will need to genera
 
 **Keep the Apple Developer window open as you will need to return here to upload your `CSRs`**
 
-##Create A Signing Request
+## Create A Signing Request
 
 Open the Keychain Access application on your Mac. This can be found in Applications → Utilities, or by searching via Spotlight.
 
@@ -55,7 +55,7 @@ You will be prompted save the certificate. Give you certificate a name and save 
 
 **Note that you must create separate `CSRs` for Production and Development certificates. Follow steps 1 - 5 again to create a second certificate.**
 
-##Upload the Signing Request
+## Upload the Signing Request
 
 Navigate back to the Apple Developer Portal and select `Create Certificate` in the `Development SSL Certificate` section.
 
@@ -75,7 +75,7 @@ Click the Download button to download your certificate to your computer, then cl
 
 Once your certificate is downloaded, double click on the certificate to automatically add it to your Keychain.
 
-##Export Certificate from Keychain
+## Export Certificate from Keychain
 
 Open up the Keychain Access application and locate your certificate. Right click on the certificate and select “Export “YOUR_CERTIFICATE_NAME”.
 
@@ -93,7 +93,7 @@ You will then be asked to enter the admin password for your computer to complete
 
 ![image alt text](ios-push-upload11.jpg)
 
-##Creating/Refreshing a Provisioning Profile
+## Creating/Refreshing a Provisioning Profile
 
  1. Navigate back to the Apple Developer Portal.  Select Provisioning Profiles.
  2. Click on the `+` button in the upper right corner to create a new provisioning profile.
@@ -106,7 +106,7 @@ You will then be asked to enter the admin password for your computer to complete
 
 If you have already created a Provisioning Profile in the past you will need to refresh it once you've created your Push Certificate.
 
-#Upload Your Certificate to Layer
+# Upload Your Certificate to Layer
 
 ```emphasis
 Please note, Layer supports both production and development Apple Push Notifications. You can upload up to 5 different certificates per project. Layer will automatically detect the type of certificate you've uploaded and use the correct one at runtime.

--- a/ios/guides/richcontent.md
+++ b/ios/guides/richcontent.md
@@ -36,7 +36,7 @@ if (error) {
 }
 ```
 
-###Progress Feedback
+### Progress Feedback
 
 Both auto-download and on-demand download report progress of the download transfer through `LYRProgress` which can be accessed depending on download type.
 ```objc

--- a/ios/integration/announcements.md
+++ b/ios/integration/announcements.md
@@ -1,4 +1,4 @@
-#Announcements
+# Announcements
 Announcements are a special `LYRMessage` type sent to a list of users or all users of the application that will arrive outside of the context of a conversation (the conversation property will be null). Announcements can only be sent through your web service using the [Platform API](https://developer.layer.com/docs/platform).
 
 ## Fetching Announcements

--- a/ios/integration/authentication.md
+++ b/ios/integration/authentication.md
@@ -1,4 +1,4 @@
-#Authenticate
+# Authenticate
 
 Once connected, Layer requires every user to be authenticated before they can send and receive messages. The Authentication process lets you explicitly allow a given user to communicate with other users in your App. A user is defined by their User ID, which can be any sort of unique identifer, including ones that you are already using for user managment (this could be a UDID, username, email address, phone number, etc).
 

--- a/ios/integration/installation-and-setup.md
+++ b/ios/integration/installation-and-setup.md
@@ -26,7 +26,7 @@ $ pod install --verbose
 
 Cocoapods will download and install LayerKit and also create a .xcworkspace project.
 
-##Connect LayerKit
+## Connect LayerKit
 
 Import the LayerKit headers into your `AppDelegate.h`
 

--- a/ios/integration/metadata.md
+++ b/ios/integration/metadata.md
@@ -1,4 +1,4 @@
-#Metadata
+# Metadata
 Metadata provides an elegant mechanism for expressing and synchronizing contextual information about conversations. This is implemented as a free-form structure of string key-value pairs that is automatically synchronized among the participants in a conversation. Example use cases of metadata include:
 
 1. Setting a conversation title.

--- a/ios/integration/querying.md
+++ b/ios/integration/querying.md
@@ -43,7 +43,7 @@ query.predicate = [LYRPredicate predicateWithProperty:@"conversation" predicateO
 
 Properties that support querying are identified by the `LYR_QUERYABLE_PROPERTY` macro.
 
-##Sorting results
+## Sorting results
 
 Applications can describe the sort order in which the query results should be returned. This is done by setting a value for the `sortDescriptors` property on `LYRQuery` objects. This value must be an array of `NSSortDescriptor` instances.
 

--- a/ios/quick-start/setup.md
+++ b/ios/quick-start/setup.md
@@ -1,4 +1,4 @@
-#Geting started with Layer
+# Geting started with Layer
 
 ```emphasis
 If you are interested in trying out Atlas, Layer's open source user interface components, visit [Experience Atlas](/signup/atlas).


### PR DESCRIPTION
They broke because they didn't have a space after the #