### PR TITLE
Add link to Python platform client

### DIFF
--- a/platform/platform-api/libraries.md
+++ b/platform/platform-api/libraries.md
@@ -14,5 +14,6 @@ Note that these libraries support requests from your **servers** only.
 |------------|---------|-------------|
 | Ruby       | [layer-ruby](https://rubygems.org/gems/layer-ruby) | Ruby library maintained by [benedikt](https://github.com/benedikt/layer-ruby). |
 | Ruby       | [layer-api](https://rubygems.org/gems/layer-api) | Ruby library maintained by [cakejelly](https://github.com/cakejelly/layer-api). |
+| Python     | [LayerClient](https://pypi.python.org/pypi/LayerClient) | Python library maintained by [Jana](https://github.com/Jana-Mobile/layer-python). |
 
 *Your library not on this list? Submit a pull request [here](https://github.com/layerhq/documentation/blob/master/platform/platform-api/libraries.md).*


### PR DESCRIPTION
Add a link to the 3rd party Platform client library maintained by Jana