### PR TITLE
URL parameters should reflect UUID

### DIFF
--- a/platform/platform-api/CHANGELOG.md
+++ b/platform/platform-api/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Layer Platform API Change Log
-
-## 1.0
-
-TODO...

--- a/platform/platform-api/block-users.md
+++ b/platform/platform-api/block-users.md
@@ -10,7 +10,7 @@ The Layer Platform API allows you to manage the Layer Block List in order to ali
 Supports bulk operations for updating the Block List for `user_id`. Requires `Content-Type: application/vnd.layer-patch.json`.
 
 ```request
-PATCH https://api.layer.com/apps/:app_id/users/:user_id
+PATCH https://api.layer.com/apps/:app_uuid/users/:user_id
 ```
 
 ### Parameters

--- a/platform/platform-api/block-users.md
+++ b/platform/platform-api/block-users.md
@@ -10,7 +10,7 @@ The Layer Platform API allows you to manage the Layer Block List in order to ali
 Supports bulk operations for updating the Block List for `user_id`. Requires `Content-Type: application/vnd.layer-patch.json`.
 
 ```request
-PATCH https://api.layer.com/apps/:app_uuid/users/:user_id
+PATCH /apps/:app_uuid/users/:user_id
 ```
 
 ### Parameters

--- a/webhooks/payloads/conversation-deleted.md
+++ b/webhooks/payloads/conversation-deleted.md
@@ -1,4 +1,4 @@
-# `conversation.deleted`
+# Conversation Deleted
 
 A `conversation.deleted` event is sent when a Conversation is globally deleted.  Note that there are other forms of deletion; these do not at this time trigger a webhook event.
 

--- a/webhooks/rest/activate.md
+++ b/webhooks/rest/activate.md
@@ -8,7 +8,7 @@ If the webhook status is `inactive`, you can use this API to start the process o
 Failing to complete the [Verification Step](#verify) will cause your webhook status to revert to `inactive`.
 
 ```request
-POST /apps/:app_id/webhooks/:webhook_id/activate
+POST /apps/:app_uuid/webhooks/:webhook_uuid/activate
 ```
 
 ### Response `200 (OK)`

--- a/webhooks/rest/deactivate.md
+++ b/webhooks/rest/deactivate.md
@@ -3,7 +3,7 @@
 If you want to pause activity around a webhook, you can deactivate it, and then reactivate it later.
 
 ```request
-POST /apps/:app_id/webhooks/:webhook_id/deactivate
+POST /apps/:app_uuid/webhooks/:webhook_uuid/deactivate
 ```
 
 ### Response `200 (OK)`

--- a/webhooks/rest/delete.md
+++ b/webhooks/rest/delete.md
@@ -3,7 +3,7 @@
 You may deactivate a webhook if you will need it later, but if you don't need it later, deleting the webhook will keep your webhook list easier to work with.
 
 ```request
-DELETE /apps/:app_id/webhooks/:webhook_id
+DELETE /apps/:app_uuid/webhooks/:webhook_uuid
 ```
 
-### Response `204 (No Content)
+### Response `204 (No Content)`

--- a/webhooks/rest/get.md
+++ b/webhooks/rest/get.md
@@ -3,7 +3,7 @@
 You can get the details and status of a single webhook by requesting it from the API:
 
 ```request
-GET /apps/:app_id/webhooks/:webhook_id
+GET /apps/:app_uuid/webhooks/:webhook_uuid
 ```
 
 ### Response `200 (OK)`

--- a/webhooks/rest/list.md
+++ b/webhooks/rest/list.md
@@ -3,7 +3,7 @@
 You can request a list of all of your webhooks from the API:
 
 ```request
-GET /apps/:app_id/webhooks
+GET /apps/:app_uuid/webhooks
 ```
 
 ### Response `200 (OK)`

--- a/webhooks/rest/register.md
+++ b/webhooks/rest/register.md
@@ -13,7 +13,7 @@ You can register a new webhook using the following endpoint.
 | **config**   | dictionary   | A free form dictionary of supplemental data specific to the webhook |
 
 ```request
-POST /apps/:app_id/webhooks
+POST /apps/:app_uuid/webhooks
 ```
 
 ### Example Request: Register a Webhook


### PR DESCRIPTION
To avoid confusion we should name all URL parameters with _uuid suffix
to prevent people putting full layer IDs in the URL path.